### PR TITLE
[#72]feature: 모임 목록페이지 무한 스크롤 구현[PLAK-174]

### DIFF
--- a/src/components/common/GatheringFilterSort.tsx
+++ b/src/components/common/GatheringFilterSort.tsx
@@ -4,7 +4,7 @@ import { usePathname } from "next/navigation";
 
 import Dropdown from "@/components/common/Dropdown";
 import FilterCalendar from "@/components/common/FilterCalendar";
-import { OFFLINE_TAB } from "@/constants/gathering";
+import { ONLINE_PATH } from "@/constants/gatheringFilterParams";
 import { SORT_OPTION } from "@/constants/ui";
 import useCustomSearchParams from "@/hooks/useCustomSearchParams";
 
@@ -15,7 +15,7 @@ const GatheringFilterSort = () => {
   return (
     <section className="mb-6 flex items-center justify-between">
       <div className="flex items-center justify-center gap-2">
-        {pathname === OFFLINE_TAB && (
+        {pathname === ONLINE_PATH && (
           <Dropdown onSelect={value => setSearchParams({ location: value })} />
         )}
         <FilterCalendar />

--- a/src/components/common/GatheringFilterSort.tsx
+++ b/src/components/common/GatheringFilterSort.tsx
@@ -4,7 +4,7 @@ import { usePathname } from "next/navigation";
 
 import Dropdown from "@/components/common/Dropdown";
 import FilterCalendar from "@/components/common/FilterCalendar";
-import { ONLINE_PATH } from "@/constants/gatheringFilterParams";
+import { OFFLINE_PATH } from "@/constants/gatheringFilterParams";
 import { SORT_OPTION } from "@/constants/ui";
 import useCustomSearchParams from "@/hooks/useCustomSearchParams";
 
@@ -15,7 +15,7 @@ const GatheringFilterSort = () => {
   return (
     <section className="mb-6 flex items-center justify-between">
       <div className="flex items-center justify-center gap-2">
-        {pathname === ONLINE_PATH && (
+        {pathname === OFFLINE_PATH && (
           <Dropdown onSelect={value => setSearchParams({ location: value })} />
         )}
         <FilterCalendar />

--- a/src/components/layout/MainCardItem.tsx
+++ b/src/components/layout/MainCardItem.tsx
@@ -9,6 +9,8 @@ import { IoMdPerson } from "react-icons/io";
 import { MdWavingHand } from "react-icons/md";
 import { RxDividerVertical } from "react-icons/rx";
 
+import { ONLINE } from "@/constants/gatheringFilterParams";
+
 import DateTimeTag from "../common/DateTimeTag";
 import DeadlineTag from "../common/DeadlineTag";
 import FavoriteButton from "../common/FavoriteButton";
@@ -66,7 +68,7 @@ const MainCardItem = ({
                   <p className="text-lg font-semibold text-gray-800">{name}</p>
                   <RxDividerVertical className="text-gray-900" />
                   <span className="ml-[3px] min-w-16 text-sm text-gray-700">
-                    {location === "홍대입구" ? "온라인" : location}
+                    {location === ONLINE.location ? "온라인" : location}
                   </span>
                 </div>
                 <div className="flex items-center gap-2">

--- a/src/components/navigations/MainTab.tsx
+++ b/src/components/navigations/MainTab.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
-import { ONLINE_PARAMS, ONLINE_TAB } from "@/constants/gathering";
+import { ONLINE, ONLINE_PATH } from "@/constants/gatheringFilterParams";
 import { MAIN_TAB } from "@/constants/ui";
 import useCustomSearchParams from "@/hooks/useCustomSearchParams";
 import { cn } from "@/lib/utils";
@@ -20,9 +20,7 @@ const MainTab = () => {
           href={tab.href}
           aria-label="메인 주제 탭"
           className="relative"
-          onClick={() =>
-            pathname === ONLINE_TAB && setSearchParams(ONLINE_PARAMS)
-          }
+          onClick={() => pathname === ONLINE_PATH && setSearchParams(ONLINE)}
         >
           <span
             className={cn(

--- a/src/components/navigations/SubTab.tsx
+++ b/src/components/navigations/SubTab.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 import { Button } from "@/components/ui/Button";
-import { OFFLINE_TAB } from "@/constants/gathering";
+import { ONLINE_PATH } from "@/constants/gatheringFilterParams";
 import { SUB_TAB } from "@/constants/ui";
 import useCustomSearchParams from "@/hooks/useCustomSearchParams";
 import { cn } from "@/lib/utils";
@@ -17,9 +17,9 @@ const SubTab = () => {
 
   return (
     <div className="align-center flex gap-2">
-      {SUB_TAB[pathname === OFFLINE_TAB ? "OFFLINE" : "ONLINE"].map(
+      {SUB_TAB[pathname === ONLINE_PATH ? "OFFLINE" : "ONLINE"].map(
         (tab, i) => (
-          <Link href={tab.value ? `?type=${tab.value}` : OFFLINE_TAB} key={i}>
+          <Link href={tab.value ? `?type=${tab.value}` : ONLINE_PATH} key={i}>
             <Button
               variant="default"
               aria-label="서브 주제 탭"

--- a/src/components/navigations/SubTab.tsx
+++ b/src/components/navigations/SubTab.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 import { Button } from "@/components/ui/Button";
-import { ONLINE_PATH } from "@/constants/gatheringFilterParams";
+import { OFFLINE_PATH, ONLINE_PATH } from "@/constants/gatheringFilterParams";
 import { SUB_TAB } from "@/constants/ui";
 import useCustomSearchParams from "@/hooks/useCustomSearchParams";
 import { cn } from "@/lib/utils";
@@ -17,7 +17,7 @@ const SubTab = () => {
 
   return (
     <div className="align-center flex gap-2">
-      {SUB_TAB[pathname === ONLINE_PATH ? "OFFLINE" : "ONLINE"].map(
+      {SUB_TAB[pathname === OFFLINE_PATH ? "OFFLINE" : "ONLINE"].map(
         (tab, i) => (
           <Link href={tab.value ? `?type=${tab.value}` : ONLINE_PATH} key={i}>
             <Button

--- a/src/constants/gathering.ts
+++ b/src/constants/gathering.ts
@@ -37,25 +37,3 @@ export const SUB_SERVICE_LIST = {
     { name: "예술", value: "WORKATION" },
   ],
 } as const;
-
-export const ONLINE_TAB = "/gathering/online";
-
-export const OFFLINE_TAB = "/gathering/offline";
-
-export const ONLINE_PARAMS = { location: "홍대입구" };
-
-interface FilterTabValue {
-  maintab: number;
-  subtab: number;
-}
-
-interface FilterTab {
-  [key: string]: FilterTabValue;
-}
-
-export const FILTER_TAB: FilterTab = {
-  OFFICE_STRETCHING: { maintab: 0, subtab: 1 },
-  MINDFULNESS: { maintab: 0, subtab: 2 },
-  WORKATION: { maintab: 0, subtab: 3 },
-  online: { maintab: 1, subtab: 0 },
-} as const;

--- a/src/constants/gatheringFilterParams.ts
+++ b/src/constants/gatheringFilterParams.ts
@@ -1,0 +1,8 @@
+//모임 목록 페이지에서 한번에 보여줄 페이지 수
+export const ITEMS_PER_PAGE = 10;
+
+export const OFFLINE_PATH = "/gathering/offline";
+
+export const ONLINE_PATH = "/gathering/online";
+
+export const ONLINE = { location: "홍대입구" };

--- a/src/hooks/gathering/useGatheringFilterParams.ts
+++ b/src/hooks/gathering/useGatheringFilterParams.ts
@@ -1,14 +1,15 @@
+import { ONLINE, ONLINE_PATH } from "@/constants/gatheringFilterParams";
 import { FilterParamsObj } from "@/types/gathering";
 
-const useConvertToQueryStr = (paramsObj: FilterParamsObj) => {
-  const type = paramsObj.type;
+const useGatheringFilterParams = (
+  pathname: string,
+  paramsObj: FilterParamsObj,
+) => {
   const location = paramsObj.location;
   const sortOption = paramsObj.sort;
 
-  if (type === "online") {
-    paramsObj["location"] = "홍대입구";
-
-    delete paramsObj.type;
+  if (pathname === ONLINE_PATH) {
+    paramsObj["location"] = ONLINE.location;
   }
 
   if (location === "전체") {
@@ -19,10 +20,10 @@ const useConvertToQueryStr = (paramsObj: FilterParamsObj) => {
     let order = "";
 
     switch (sortOption) {
-      case "participantCount":
+      case "participantCount": //인기많은순 정렬
         order = "desc";
 
-      case "registrationEnd":
+      case "registrationEnd": //마감임박순 정렬
         order = "asc";
     }
 
@@ -32,4 +33,4 @@ const useConvertToQueryStr = (paramsObj: FilterParamsObj) => {
   return new URLSearchParams(paramsObj).toString();
 };
 
-export default useConvertToQueryStr;
+export default useGatheringFilterParams;

--- a/src/hooks/useIntersectionObserver.tsx
+++ b/src/hooks/useIntersectionObserver.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+interface useIntersectionObserverProps {
+  root?: null;
+  rootMargin?: string;
+  threshold?: number;
+  onIntersect: IntersectionObserverCallback;
+}
+
+const useIntersectionObserver = ({
+  root,
+  rootMargin = "0px",
+  threshold = 0.3,
+  onIntersect,
+}: useIntersectionObserverProps) => {
+  const [target, setTarget] = useState<HTMLElement | null | undefined>(null);
+
+  useEffect(() => {
+    if (!target) return;
+
+    const observer: IntersectionObserver = new IntersectionObserver(
+      onIntersect,
+      { root, rootMargin, threshold },
+    );
+    observer.observe(target);
+
+    return () => observer.unobserve(target);
+  }, [onIntersect, root, rootMargin, target, threshold]);
+
+  return { setTarget };
+};
+
+export default useIntersectionObserver;

--- a/src/services/gathering/GatheringService.ts
+++ b/src/services/gathering/GatheringService.ts
@@ -1,3 +1,4 @@
+import { ITEMS_PER_PAGE } from "@/constants/gatheringFilterParams";
 import Service from "@/services/Service";
 import { IGathering } from "@/types/gathering";
 import { getCookieOfToken } from "@/utils/cookieToken";
@@ -8,18 +9,18 @@ class GatheringService extends Service {
     this.setToken(token || "");
   }
 
-  getGatheringList(type?: string, params?: string) {
-    const isOnline = type === "online";
-    const onlineFilter = isOnline ? "?location=홍대입구" : "";
-    const filterParams = isOnline ? onlineFilter + `&${params}` : `?${params}`;
+  getGatheringList(pageParam?: number, params?: string) {
+    if (!pageParam) pageParam = 1;
 
-    if (isOnline && !params)
-      return this.http.get<IGathering[]>(`/gatherings${onlineFilter}`);
+    const sliceParams = `limit=${ITEMS_PER_PAGE}&offset=${(pageParam - 1) * 10}`;
 
-    if (params)
-      return this.http.get<IGathering[]>(`/gatherings${filterParams}`);
-
-    return this.http.get<IGathering[]>(`/gatherings`);
+    if (params) {
+      return this.http.get<IGathering[]>(
+        `/gatherings?${params}&${sliceParams}`,
+      );
+    } else {
+      return this.http.get<IGathering[]>(`/gatherings?${sliceParams}`);
+    }
   }
   getGatheringDetail(id: string) {
     const data = this.http.get<IGathering>(`/gatherings/${id}`);


### PR DESCRIPTION
## 개요
모임 목록페이지 무한 스크롤을 구현했습니다. 모임 목록 페이지와 관련한 코드 수정과 리팩토링을 진행했습니다.

## PR 유형

어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 파일 혹은 폴더명 수정

## 세부 내용
![화면 기록 2025-03-25 오후 7 25 13](https://github.com/user-attachments/assets/a2923bfa-8c32-4ad2-ae5a-a414bfd9a6b8)

- gathering.ts(상수 파일)에서 Filter Parameter 관련 부분을 분리한 gatheringFilterParams.ts을 생성했습니다.
- 모임 전체 데이터 GET API를 호출하는 getGatheringList(GatheringService.ts)의 로직을 단순하게 변경하는 리팩토링을 진행했습니다.
- URL의 parameter 형식을 변경하는 훅의 이름을 useGahteringFilterParams로 변경했습니다.
- target 요소와 겹치는 부분을 감지하는 useIntersectionObserver 훅을 개발했습니다.

## PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 코드리뷰 검토 사항을 적어주세요
- 전체적인 코드 구현 확인을 부탁드립니다.