### PR TITLE
[#72]fix: GATHERING.listByParams 쿼리키에 탭 파라미터 추가 및 마감 모임 필터링[PLAK-89]

### DIFF
--- a/src/app/all-reviews/[tab]/_components/ReviewFilterSort.tsx
+++ b/src/app/all-reviews/[tab]/_components/ReviewFilterSort.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { usePathname } from "next/navigation";
+import { useState } from "react";
 
 import Dropdown from "@/components/common/Dropdown";
 import FilterCalendar from "@/components/common/FilterCalendar";
@@ -11,13 +12,18 @@ const ReviewFilterSort = () => {
   const pathname = usePathname();
   const { setSearchParams } = useCustomSearchParams();
 
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+
   return (
     <section className="mb-6 flex items-center justify-between gap-1">
       <div className="flex items-center justify-center gap-2">
         {pathname === REVIEW_OFFLINE_PATH && (
           <Dropdown onSelect={value => setSearchParams({ location: value })} />
         )}
-        <FilterCalendar />
+        <FilterCalendar
+          selectedDate={selectedDate}
+          setSelectedDate={setSelectedDate}
+        />
       </div>
       <div>
         <Dropdown

--- a/src/app/gathering/[tab]/page.tsx
+++ b/src/app/gathering/[tab]/page.tsx
@@ -8,7 +8,7 @@ import { notFound } from "next/navigation";
 import FetchBoundary from "@/components/boundary/FetchBoundary";
 import MainCardList from "@/components/layout/MainCardList";
 import MainCardListSkeleton from "@/components/skeletons/MainCardListSkeleton";
-import { prefetchGateringInfiniteList } from "@/hooks/gathering/useGatheringInfiniteList";
+// import { prefetchGateringInfiniteList } from "@/hooks/gathering/useGatheringInfiniteList";
 import { MainTab, MainTabSchema } from "@/types/gathering/main-tab";
 
 type PageProps = {
@@ -28,12 +28,13 @@ const Page = async ({ params }: PageProps) => {
     notFound();
   }
 
-  await prefetchGateringInfiniteList(queryClient, tab);
+  //수정 예정
+  //await prefetchGateringInfiniteList(queryClient, tab);
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
       <FetchBoundary fallback={<MainCardListSkeleton />}>
-        <MainCardList />
+        <MainCardList tab={tab} />
       </FetchBoundary>
     </HydrationBoundary>
   );

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -22,6 +22,7 @@ interface IDropdownProps {
   option?: Array<IOption>;
   placeholder?: string;
   type?: "default" | "sort" | "form";
+  defaultValue?: string;
   onSelect?: (value: string) => void;
 }
 
@@ -29,10 +30,15 @@ const Dropdown = ({
   option = LOCATION_OPTION,
   placeholder,
   type = "default",
+  defaultValue,
   onSelect,
 }: IDropdownProps) => {
   return (
-    <Select onValueChange={onSelect}>
+    <Select
+      onValueChange={onSelect}
+      defaultValue={defaultValue}
+      value={defaultValue}
+    >
       <SelectTrigger
         className={cn(
           "min-w-[110px] justify-between rounded-xl bg-white",

--- a/src/components/common/FilterCalendar.tsx
+++ b/src/components/common/FilterCalendar.tsx
@@ -15,29 +15,37 @@ import useCustomSearchParams from "@/hooks/useCustomSearchParams";
 
 import { Calendar } from "../ui/Calendar";
 
-const FilterCalendar = () => {
+interface IFilterCalendarProps {
+  selectedDate: string | null;
+  setSelectedDate: React.Dispatch<React.SetStateAction<string | null>>;
+}
+
+const FilterCalendar = ({
+  selectedDate,
+  setSelectedDate,
+}: IFilterCalendarProps) => {
   const { setSearchParams } = useCustomSearchParams();
 
   const [isCalendarOpen, setIsCalendarOpen] = useState<boolean>(false);
   const [date, setDate] = useState<Date>(new Date());
-  const [selectedDate, setSelectedDate] = useState<string | null>(null);
 
-  const handleClick = (type?: string) => {
+  const onClickDate = (type?: string) => {
     const formatDate = dayjs(date).format("YYYY-MM-DD");
+    const isReset = type === "reset";
     let value = "";
 
-    if (type === "reset") {
+    if (isReset) {
       setDate(new Date());
       value = "";
     } else {
       value = formatDate;
     }
+    setSelectedDate(isReset ? null : formatDate);
+    setIsCalendarOpen(false);
+
     setSearchParams({
       date: value,
     });
-
-    setSelectedDate(type === "reset" ? null : formatDate);
-    setIsCalendarOpen(false);
   };
 
   return (
@@ -70,18 +78,14 @@ const FilterCalendar = () => {
             <Button
               variant={"purple-outline"}
               className="h-[40px] w-[118px]"
-              onClick={() => {
-                handleClick("reset");
-              }}
+              onClick={() => onClickDate("reset")}
             >
               초기화
             </Button>
             <Button
               variant={"purple"}
               className="h-[40px] w-[118px]"
-              onClick={() => {
-                handleClick();
-              }}
+              onClick={() => onClickDate()}
             >
               적용
             </Button>

--- a/src/components/common/FilterCalendar.tsx
+++ b/src/components/common/FilterCalendar.tsx
@@ -62,9 +62,7 @@ const FilterCalendar = () => {
             mode="single"
             selected={date}
             onDayClick={setDate}
-            disabled={date =>
-              date > new Date() || date < new Date("1900-01-01")
-            }
+            fromDate={new Date()}
             initialFocus
             locale={ko}
           />

--- a/src/components/common/FilterCalendar.tsx
+++ b/src/components/common/FilterCalendar.tsx
@@ -18,11 +18,13 @@ import { Calendar } from "../ui/Calendar";
 interface IFilterCalendarProps {
   selectedDate: string | null;
   setSelectedDate: React.Dispatch<React.SetStateAction<string | null>>;
+  disableType?: "afterToday" | undefined;
 }
 
 const FilterCalendar = ({
   selectedDate,
   setSelectedDate,
+  disableType,
 }: IFilterCalendarProps) => {
   const { setSearchParams } = useCustomSearchParams();
 
@@ -70,7 +72,7 @@ const FilterCalendar = ({
             mode="single"
             selected={date}
             onDayClick={setDate}
-            fromDate={new Date()}
+            fromDate={disableType === "afterToday" ? new Date() : undefined}
             initialFocus
             locale={ko}
           />

--- a/src/components/common/GatheringFilterSort.tsx
+++ b/src/components/common/GatheringFilterSort.tsx
@@ -1,24 +1,49 @@
 "use client";
 
 import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
 
 import Dropdown from "@/components/common/Dropdown";
 import FilterCalendar from "@/components/common/FilterCalendar";
 import { OFFLINE_PATH } from "@/constants/gatheringFilterParams";
 import { SORT_OPTION } from "@/constants/ui";
 import useCustomSearchParams from "@/hooks/useCustomSearchParams";
+import useTabStore from "@/stores/useTabStore";
 
 const GatheringFilterSort = () => {
+  const isSubTabChange = useTabStore(state => state.isSubTabChange);
+  const onSubTabChangeOff = useTabStore(state => state.onSubTabChangeOff);
+
+  const [defaultValue, setDefaultValue] = useState<undefined | string>(
+    undefined,
+  );
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+
   const pathname = usePathname();
   const { setSearchParams } = useCustomSearchParams();
 
+  useEffect(() => {
+    // 서브탭 이동시 필터, 정렬 부분 초기화
+    if (isSubTabChange) {
+      onSubTabChangeOff();
+      setSelectedDate(null);
+      setDefaultValue("");
+    }
+  }, [isSubTabChange, onSubTabChangeOff]);
+
   return (
     <section className="mb-6 flex items-center justify-between">
-      <div className="flex items-center justify-center gap-2">
+      <div className="justfify-center flex items-center gap-2">
         {pathname === OFFLINE_PATH && (
-          <Dropdown onSelect={value => setSearchParams({ location: value })} />
+          <Dropdown
+            onSelect={value => setSearchParams({ location: value })}
+            defaultValue={defaultValue}
+          />
         )}
-        <FilterCalendar />
+        <FilterCalendar
+          selectedDate={selectedDate}
+          setSelectedDate={setSelectedDate}
+        />
       </div>
       <div>
         <Dropdown
@@ -26,6 +51,7 @@ const GatheringFilterSort = () => {
           placeholder="정렬"
           option={SORT_OPTION}
           onSelect={value => setSearchParams({ sortBy: value })}
+          defaultValue={defaultValue}
         />
       </div>
     </section>

--- a/src/components/common/GatheringFilterSort.tsx
+++ b/src/components/common/GatheringFilterSort.tsx
@@ -43,6 +43,7 @@ const GatheringFilterSort = () => {
         <FilterCalendar
           selectedDate={selectedDate}
           setSelectedDate={setSelectedDate}
+          disableType={"afterToday"}
         />
       </div>
       <div>

--- a/src/components/layout/MainCardItem.tsx
+++ b/src/components/layout/MainCardItem.tsx
@@ -68,7 +68,7 @@ const MainCardItem = ({
           <div className="flex w-full items-center justify-between">
             <div className="flex flex-col items-start justify-center gap-2">
               <div className="flex items-center justify-center">
-                <p className="max-h-[30px] w-80 max-w-[450px] overflow-hidden text-ellipsis whitespace-nowrap text-lg font-semibold text-gray-800">
+                <p className="max-h-[30px] max-w-[190px] overflow-hidden text-ellipsis whitespace-nowrap text-lg font-semibold text-gray-800 md:max-w-[400px]">
                   {name}
                 </p>
                 <RxDividerVertical className="text-gray-900" />

--- a/src/components/layout/MainCardItem.tsx
+++ b/src/components/layout/MainCardItem.tsx
@@ -47,74 +47,78 @@ const MainCardItem = ({
   const isOpend = dayjs(registrationEnd).isAfter(today); // 모임오픈 여부 (모임이 종료되지 않았을 경우: true)
 
   return (
-    <>
-      <Link href={`/gathering/detail/${id}`} className="w-full">
-        <div className="relative m-auto flex min-w-[343px] flex-col overflow-hidden rounded-3xl border-2 border-gray-100 bg-white md:flex-row lg:flex-row">
-          <div className="relative h-[156px] w-full min-w-[280px] md:w-[280px] lg:w-[280px]">
-            <Image
-              src={image || "/images/gathering_default.png"}
-              alt={image ? name : "모임 기본 이미지"}
-              className="h-full w-full object-cover"
-              fill
-              sizes="(max-width: 768px) 50vw"
-              priority={firstPage}
-            ></Image>
-            {isOpend && <DeadlineTag registrationEnd={registrationEnd} />}
+    <article className="relative w-full">
+      <Link
+        href={`/gathering/detail/${id}`}
+        className="absolute z-10 h-full w-full"
+      ></Link>
+      <div className="relative m-auto flex min-w-[343px] flex-col overflow-hidden rounded-3xl border-2 border-gray-100 bg-white md:flex-row lg:flex-row">
+        <div className="relative h-[156px] w-full min-w-[280px] md:w-[280px] lg:w-[280px]">
+          <Image
+            src={image || "/images/gathering_default.png"}
+            alt={image ? name : "모임 기본 이미지"}
+            className="h-full w-full object-cover"
+            fill
+            sizes="(max-width: 768px) 50vw"
+            priority={firstPage}
+          ></Image>
+          {isOpend && <DeadlineTag registrationEnd={registrationEnd} />}
+        </div>
+        <div className="flex w-full flex-col items-center justify-center gap-7 p-4">
+          <div className="flex w-full items-center justify-between">
+            <div className="flex flex-col items-start justify-center gap-2">
+              <div className="flex items-center justify-center">
+                <p className="max-h-[30px] w-80 max-w-[450px] overflow-hidden text-ellipsis whitespace-nowrap text-lg font-semibold text-gray-800">
+                  {name}
+                </p>
+                <RxDividerVertical className="text-gray-900" />
+                <span className="ml-[3px] min-w-16 text-sm text-gray-700">
+                  {location === ONLINE.location ? "온라인" : location}
+                </span>
+              </div>
+              <div className="flex items-center gap-2">
+                <DateTimeTag date={dayjs(dateTime)} />
+              </div>
+            </div>
+            <FavoriteButton isFavorite={false} onToggle={() => {}} />
           </div>
-          <div className="flex w-full flex-col items-center justify-center gap-7 p-4">
-            <div className="flex w-full items-center justify-between">
-              <div className="flex flex-col items-start justify-center gap-2">
-                <div className="flex items-center justify-center">
-                  <p className="text-lg font-semibold text-gray-800">{name}</p>
-                  <RxDividerVertical className="text-gray-900" />
-                  <span className="ml-[3px] min-w-16 text-sm text-gray-700">
-                    {location === ONLINE.location ? "온라인" : location}
+          <div className="flex w-full items-center gap-6">
+            <div className="flex flex-1 flex-col items-start gap-2 md:w-[258px] lg:w-[258px]">
+              <div className="flex items-center justify-center gap-2">
+                <div className="flex items-center justify-center gap-0.5 text-gray-700">
+                  <IoMdPerson size={16} />
+                  <span className="text-sm">
+                    {participantCount}/{capacity}
                   </span>
                 </div>
-                <div className="flex items-center gap-2">
-                  <DateTimeTag date={dayjs(dateTime)} />
-                </div>
-              </div>
-              <FavoriteButton isFavorite={false} onToggle={() => {}} />
-            </div>
-            <div className="flex w-full items-center gap-6">
-              <div className="flex flex-1 flex-col items-start gap-2 md:w-[258px] lg:w-[258px]">
-                <div className="flex items-center justify-center gap-2">
-                  <div className="flex items-center justify-center gap-0.5 text-gray-700">
-                    <IoMdPerson size={16} />
-                    <span className="text-sm">
-                      {participantCount}/{capacity}
-                    </span>
+                {isConfirmed && (
+                  <div className="flex items-center justify-center gap-[7px] text-purple-500">
+                    <FaCircleCheck />
+                    <span className="text-sm">{"개설확정"}</span>
                   </div>
-                  {isConfirmed && (
-                    <div className="flex items-center justify-center gap-[7px] text-purple-500">
-                      <FaCircleCheck />
-                      <span className="text-sm">{"개설확정"}</span>
-                    </div>
-                  )}
-                </div>
-                <ProgressBar progress={progressPercentage} />
+                )}
               </div>
-              <div className="flex items-center justify-center gap-2 text-purple-500">
-                <span className="font-semibold">{"join now"}</span>
-                <FaArrowRight />
-              </div>
+              <ProgressBar progress={progressPercentage} />
+            </div>
+            <div className="flex items-center justify-center gap-2 text-purple-500">
+              <span className="font-semibold">{"join now"}</span>
+              <FaArrowRight />
             </div>
           </div>
-          {!isOpend && (
-            <>
-              <div className="absolute flex h-full w-full flex-col items-center justify-center bg-black/80 text-sm text-white">
-                <span>{"마감된 챌린지에요,"}</span>
-                <span>{"다음 기회에 만나요 🙏"}</span>
-              </div>
-              <div className="absolute right-0 mr-6 mt-6 flex h-12 w-12 items-center justify-center rounded-full bg-gray-100">
-                <MdWavingHand className="scale-x-[-1] text-purple-600" />
-              </div>
-            </>
-          )}
         </div>
-      </Link>
-    </>
+        {!isOpend && (
+          <>
+            <div className="absolute z-20 flex h-full w-full flex-col items-center justify-center bg-black/80 text-sm text-white">
+              <span>{"마감된 챌린지에요,"}</span>
+              <span>{"다음 기회에 만나요 🙏"}</span>
+            </div>
+            <div className="absolute right-0 z-20 mr-6 mt-6 flex h-12 w-12 items-center justify-center rounded-full bg-gray-100">
+              <MdWavingHand className="scale-x-[-1] text-purple-600" />
+            </div>
+          </>
+        )}
+      </div>
+    </article>
   );
 };
 

--- a/src/components/layout/MainCardList.tsx
+++ b/src/components/layout/MainCardList.tsx
@@ -2,25 +2,24 @@
 
 import { usePathname } from "next/navigation";
 
-import { ONLINE_PATH } from "@/constants/gatheringFilterParams";
-import useGatheringFilterParams from "@/hooks/gathering/useGatheringFilterParams";
 import { useSuspenseGatheringInfiniteList } from "@/hooks/gathering/useGatheringInfiniteList";
 import useCustomSearchParams from "@/hooks/useCustomSearchParams";
 import useIntersectionObserver from "@/hooks/useIntersectionObserver";
+import gatheringFilterParams from "@/utils/gatheringFilterParams";
 
 import MainCardItem from "./MainCardItem";
 
-const MainCardList = () => {
-  const pathname = usePathname();
+interface IMainCardListProps {
+  tab: string;
+}
 
+const MainCardList = ({ tab }: IMainCardListProps) => {
+  const pathname = usePathname();
   const { searchParamsObj } = useCustomSearchParams();
-  const params = useGatheringFilterParams(pathname, searchParamsObj);
+  const params = gatheringFilterParams(pathname, searchParamsObj);
 
   const { data, status, hasNextPage, fetchNextPage } =
-    useSuspenseGatheringInfiniteList(
-      pathname === ONLINE_PATH ? "online" : "offline",
-      params,
-    );
+    useSuspenseGatheringInfiniteList(tab, params);
 
   const onIntersect: IntersectionObserverCallback = ([{ isIntersecting }]) => {
     if (isIntersecting && hasNextPage) {

--- a/src/components/layout/MainCardList.tsx
+++ b/src/components/layout/MainCardList.tsx
@@ -5,7 +5,7 @@ import { usePathname } from "next/navigation";
 import { useSuspenseGatheringInfiniteList } from "@/hooks/gathering/useGatheringInfiniteList";
 import useCustomSearchParams from "@/hooks/useCustomSearchParams";
 import useIntersectionObserver from "@/hooks/useIntersectionObserver";
-import gatheringFilterParams from "@/utils/gatheringFilterParams";
+import { updateGatheringParams } from "@/utils/gatheringFilterParams";
 
 import MainCardItem from "./MainCardItem";
 
@@ -16,7 +16,7 @@ interface IMainCardListProps {
 const MainCardList = ({ tab }: IMainCardListProps) => {
   const pathname = usePathname();
   const { searchParamsObj } = useCustomSearchParams();
-  const params = gatheringFilterParams(pathname, searchParamsObj);
+  const params = updateGatheringParams(pathname, searchParamsObj);
 
   const { data, status, hasNextPage, fetchNextPage } =
     useSuspenseGatheringInfiniteList(tab, params);

--- a/src/components/navigations/SubTab.tsx
+++ b/src/components/navigations/SubTab.tsx
@@ -8,8 +8,11 @@ import { OFFLINE_PATH, ONLINE_PATH } from "@/constants/gatheringFilterParams";
 import { SUB_TAB } from "@/constants/ui";
 import useCustomSearchParams from "@/hooks/useCustomSearchParams";
 import { cn } from "@/lib/utils";
+import useTabStore from "@/stores/useTabStore";
 
 const SubTab = () => {
+  const onSubTabChangeOn = useTabStore(state => state.onSubTabChangeOn);
+
   const pathname = usePathname();
   const { searchParams, setSearchParams } = useCustomSearchParams();
 
@@ -25,7 +28,10 @@ const SubTab = () => {
           <Button
             variant="default"
             aria-label="서브 주제 탭"
-            onClick={() => setSearchParams({ type: tab.value })}
+            onClick={() => {
+              setSearchParams({ type: tab.value });
+              onSubTabChangeOn();
+            }}
             className={cn(
               "rounded-xl px-4 py-2.5",
               tab.value !== type &&

--- a/src/components/navigations/SubTab.tsx
+++ b/src/components/navigations/SubTab.tsx
@@ -14,27 +14,28 @@ const SubTab = () => {
   const { searchParams, setSearchParams } = useCustomSearchParams();
 
   const type = searchParams.get("type") || "";
+  const isOffline = pathname === OFFLINE_PATH;
+
+  const href = pathname === OFFLINE_PATH ? OFFLINE_PATH : ONLINE_PATH;
 
   return (
     <div className="align-center flex gap-2">
-      {SUB_TAB[pathname === OFFLINE_PATH ? "OFFLINE" : "ONLINE"].map(
-        (tab, i) => (
-          <Link href={tab.value ? `?type=${tab.value}` : ONLINE_PATH} key={i}>
-            <Button
-              variant="default"
-              aria-label="서브 주제 탭"
-              onClick={() => setSearchParams({ type: tab.value })}
-              className={cn(
-                "rounded-xl px-4 py-2.5",
-                tab.value !== type &&
-                  "bg-gray-200 text-black hover:bg-gray-200/90",
-              )}
-            >
-              {tab.name}
-            </Button>
-          </Link>
-        ),
-      )}
+      {SUB_TAB[isOffline ? "OFFLINE" : "ONLINE"].map((tab, i) => (
+        <Link href={tab.value ? `?type=${tab.value}` : href} key={i}>
+          <Button
+            variant="default"
+            aria-label="서브 주제 탭"
+            onClick={() => setSearchParams({ type: tab.value })}
+            className={cn(
+              "rounded-xl px-4 py-2.5",
+              tab.value !== type &&
+                "bg-gray-200 text-black hover:bg-gray-200/90",
+            )}
+          >
+            {tab.name}
+          </Button>
+        </Link>
+      ))}
     </div>
   );
 };

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -9,8 +9,8 @@ export const QUERY_KEYS = {
     all: GATHERING_ALL,
     list: [...GATHERING_ALL, "list"] as const,
     myList: [...GATHERING_ALL, "myList"] as const,
-    listByParams: (params?: IGatheringFilterParams) =>
-      [...GATHERING_ALL, "list", params] as const,
+    listByParams: (tab: string, params?: IGatheringFilterParams) =>
+      [...GATHERING_ALL, "list", tab, params] as const,
     popular: [...GATHERING_ALL, "list", "popular"] as const,
     upcoming: [...GATHERING_ALL, "list", "upcoming"] as const,
     detail: (gatheringId: string) =>

--- a/src/hooks/gathering/useGatheringInfiniteList.ts
+++ b/src/hooks/gathering/useGatheringInfiniteList.ts
@@ -20,10 +20,10 @@ const filterByValue = (data: {
 });
 
 const gatheringInfiniteListQueryOption = (
-  type?: string,
+  tab: string,
   params?: IGatheringFilterParams,
 ) => ({
-  queryKey: [QUERY_KEYS.GATHERING.listByParams(params)],
+  queryKey: [QUERY_KEYS.GATHERING.listByParams(tab, params)],
   queryFn: ({ pageParam = 1 }) => {
     return anonGatheringService.getGatheringInfiniteList(pageParam, params);
   },
@@ -35,22 +35,22 @@ const gatheringInfiniteListQueryOption = (
 
     return lastPage.length > 0 ? nextPage : undefined;
   },
-  select: type === "offline" ? filterByValue : undefined,
+  select: tab === "offline" ? filterByValue : undefined,
 });
 
 export const useGatheringInfiniteList = (
-  type?: string,
+  tab: string,
   params?: IGatheringFilterParams,
 ) => {
-  return useInfiniteQuery(gatheringInfiniteListQueryOption(type, params));
+  return useInfiniteQuery(gatheringInfiniteListQueryOption(tab, params));
 };
 
 export const useSuspenseGatheringInfiniteList = (
-  type?: string,
+  tab: string,
   params?: IGatheringFilterParams,
 ) => {
   const { data, hasNextPage, fetchNextPage, status } = useSuspenseInfiniteQuery(
-    gatheringInfiniteListQueryOption(type, params),
+    gatheringInfiniteListQueryOption(tab, params),
   );
 
   return { data, hasNextPage, fetchNextPage, status };
@@ -58,10 +58,10 @@ export const useSuspenseGatheringInfiniteList = (
 
 export const prefetchGateringInfiniteList = async (
   queryClient: QueryClient,
-  type?: string,
+  tab: string,
   params?: IGatheringFilterParams,
 ) => {
   return queryClient.prefetchInfiniteQuery(
-    gatheringInfiniteListQueryOption(type, params),
+    gatheringInfiniteListQueryOption(tab, params),
   );
 };

--- a/src/hooks/gathering/useGatheringInfiniteList.ts
+++ b/src/hooks/gathering/useGatheringInfiniteList.ts
@@ -3,6 +3,7 @@ import {
   useInfiniteQuery,
   useSuspenseInfiniteQuery,
 } from "@tanstack/react-query";
+import dayjs from "dayjs";
 
 import { ONLINE } from "@/constants/gatheringFilterParams";
 import { QUERY_KEYS } from "@/constants/queryKeys";
@@ -24,8 +25,14 @@ const gatheringInfiniteListQueryOption = (
   params?: IGatheringFilterParams,
 ) => ({
   queryKey: [QUERY_KEYS.GATHERING.listByParams(tab, params)],
-  queryFn: ({ pageParam = 1 }) => {
-    return anonGatheringService.getGatheringInfiniteList(pageParam, params);
+  queryFn: async ({ pageParam = 1 }) => {
+    const gatherings = await anonGatheringService.getGatheringInfiniteList(
+      pageParam,
+      params,
+    );
+    return gatherings.filter((gathering: IGathering) =>
+      dayjs(gathering.registrationEnd).isAfter(dayjs(new Date())),
+    );
   },
   initialPageParam: 1,
   throwOnError: true,

--- a/src/services/gathering/AnonGatheringService.ts
+++ b/src/services/gathering/AnonGatheringService.ts
@@ -22,17 +22,16 @@ class AnonGatheringService extends Service {
   ) {
     if (!pageParam) pageParam = 1;
 
-    const sliceParams = `limit=${ITEMS_PER_PAGE}&offset=${(pageParam - 1) * 10}`;
-    const defaultParams = `${sliceParams}&sortBy=dateTime`;
+    const limitParams = `limit=${ITEMS_PER_PAGE}&offset=${(pageParam - 1) * 10}`;
 
     if (params && Object.keys(params).length !== 0) {
       const convertedParams = new URLSearchParams(params).toString();
 
       return this.http.get<IGathering[]>(
-        `/gatherings?${convertedParams}&${defaultParams}`,
+        `/gatherings?${convertedParams}&${limitParams}`,
       );
     } else {
-      return this.http.get<IGathering[]>(`/gatherings?${defaultParams}`);
+      return this.http.get<IGathering[]>(`/gatherings?${limitParams}`);
     }
   }
 

--- a/src/stores/useTabStore.ts
+++ b/src/stores/useTabStore.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+interface TabStore {
+  isSubTabChange: boolean;
+  onSubTabChangeOn: () => void;
+  onSubTabChangeOff: () => void;
+}
+
+const useTabStore = create<TabStore>(set => ({
+  isSubTabChange: false,
+  onSubTabChangeOn: () => set({ isSubTabChange: true }),
+  onSubTabChangeOff: () => set({ isSubTabChange: false }),
+}));
+
+export default useTabStore;

--- a/src/utils/gatheringFilterParams.ts
+++ b/src/utils/gatheringFilterParams.ts
@@ -1,7 +1,7 @@
 import { ONLINE, ONLINE_PATH } from "@/constants/gatheringFilterParams";
 import { IGatheringFilterParams } from "@/types/gathering";
 
-const useGatheringFilterParams = (
+const gatheringFilterParams = (
   pathname: string,
   paramsObj: IGatheringFilterParams,
 ) => {
@@ -33,4 +33,4 @@ const useGatheringFilterParams = (
   return paramsObj;
 };
 
-export default useGatheringFilterParams;
+export default gatheringFilterParams;

--- a/src/utils/gatheringFilterParams.ts
+++ b/src/utils/gatheringFilterParams.ts
@@ -1,12 +1,12 @@
 import { ONLINE, ONLINE_PATH } from "@/constants/gatheringFilterParams";
 import { IGatheringFilterParams } from "@/types/gathering";
 
-const gatheringFilterParams = (
+export const updateGatheringParams = (
   pathname: string,
   paramsObj: IGatheringFilterParams,
 ) => {
   const location = paramsObj.location;
-  const sortOption = paramsObj.sort;
+  const sortOption = paramsObj.sortBy;
 
   if (pathname === ONLINE_PATH) {
     paramsObj["location"] = ONLINE.location;
@@ -28,9 +28,9 @@ const gatheringFilterParams = (
     }
 
     paramsObj["sortOrder"] = order;
+  } else {
+    paramsObj["sortBy"] = "dateTime";
   }
 
   return paramsObj;
 };
-
-export default gatheringFilterParams;


### PR DESCRIPTION
## 개요
GATHERING.listByParams 쿼리키에 탭 파라미터를 추가했으며 모임 목록페이지에서의 버그와 기능을 수정했습니다.

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 파일 혹은 폴더명 수정

## 스크린샷 및 세부 내용 - 왜 해당 PR이 필요한지 자세하게 설명해주세요.
1) GATHERING.listByParams 쿼리키에 탭 파라미터 추가

2) 모임 마감 데이터 필터링

3) 모임 목록페이지 버그, 기능 수정
- 서브탭 이동시 필터, 정렬을 선택하는 드롭다운이 초기화
- 오프라인 탭에서 전체 탭 클릭시 온라인 탭으로 전환되는 버그 수정
- 정렬 parmas 잘못 설정되는 버그 수정
- 캘린더 드롭다운 선택시 오늘 이전의 날짜가 disabled 처리되도록 수정(disabledType props에 "afterType"을 설정하면 처리 가능하도록 변경)

4) UI 변경
<img width="1039" alt="image" src="https://github.com/user-attachments/assets/898179fe-75e9-42a8-b7be-fe3b4d89d95a" />
<img width="291" alt="image" src="https://github.com/user-attachments/assets/e3daea4c-1b2e-4b3c-b116-8ce4033a3311" />

- 모임 카드 내부의 name(모임이름)의 길이가 길 경우 말줄임으로 표시됩니다.

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 코드리뷰 검토 사항을 적어주세요

- 전체적인 코드 구현 확인을 부탁드립니다.