### PR TITLE
[#72]모임 페이지에서 react-query prefetch 부분 수정[PLAK-184]

### DIFF
--- a/src/app/gathering/[tab]/page.tsx
+++ b/src/app/gathering/[tab]/page.tsx
@@ -49,7 +49,7 @@ const Page = async ({ params }: PageProps) => {
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
       <FetchBoundary fallback={<MainCardListSkeleton />}>
-        <MainCardList tab={tab} />
+        <MainCardList tab={tab} filteredParams={filteredParams} />
       </FetchBoundary>
     </HydrationBoundary>
   );

--- a/src/app/gathering/[tab]/page.tsx
+++ b/src/app/gathering/[tab]/page.tsx
@@ -3,22 +3,31 @@ import {
   HydrationBoundary,
   QueryClient,
 } from "@tanstack/react-query";
+import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 
 import FetchBoundary from "@/components/boundary/FetchBoundary";
 import MainCardList from "@/components/layout/MainCardList";
 import MainCardListSkeleton from "@/components/skeletons/MainCardListSkeleton";
-// import { prefetchGateringInfiniteList } from "@/hooks/gathering/useGatheringInfiniteList";
+import { prefetchGateringInfiniteList } from "@/hooks/gathering/useGatheringInfiniteList";
 import { MainTab, MainTabSchema } from "@/types/gathering/main-tab";
+import { updateGatheringParams } from "@/utils/gatheringFilterParams";
 
 type PageProps = {
-  params: Promise<{
+  params: {
     tab: MainTab;
-  }>;
+    location: string;
+    date: string;
+    sort: string;
+    type: string;
+  };
 };
 
 const Page = async ({ params }: PageProps) => {
-  const { tab } = await params;
+  const { tab, location, date, sort, type } = params;
+
+  const headersList = headers(); //custom x-url header
+  const headerPathname = headersList.get("x-pathname") || "";
 
   const queryClient = new QueryClient();
 
@@ -28,8 +37,14 @@ const Page = async ({ params }: PageProps) => {
     notFound();
   }
 
-  //수정 예정
-  //await prefetchGateringInfiniteList(queryClient, tab);
+  const filteredParams = updateGatheringParams(headerPathname, {
+    location,
+    date,
+    sort,
+    type,
+  });
+
+  await prefetchGateringInfiniteList(queryClient, tab, filteredParams);
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/components/layout/MainCardList.tsx
+++ b/src/components/layout/MainCardList.tsx
@@ -1,25 +1,19 @@
 "use client";
 
-import { usePathname } from "next/navigation";
-
 import { useSuspenseGatheringInfiniteList } from "@/hooks/gathering/useGatheringInfiniteList";
-import useCustomSearchParams from "@/hooks/useCustomSearchParams";
 import useIntersectionObserver from "@/hooks/useIntersectionObserver";
-import { updateGatheringParams } from "@/utils/gatheringFilterParams";
+import { IGatheringFilterParams } from "@/types/gathering";
 
 import MainCardItem from "./MainCardItem";
 
 interface IMainCardListProps {
   tab: string;
+  filteredParams: IGatheringFilterParams;
 }
 
-const MainCardList = ({ tab }: IMainCardListProps) => {
-  const pathname = usePathname();
-  const { searchParamsObj } = useCustomSearchParams();
-  const params = updateGatheringParams(pathname, searchParamsObj);
-
+const MainCardList = ({ tab, filteredParams }: IMainCardListProps) => {
   const { data, status, hasNextPage, fetchNextPage } =
-    useSuspenseGatheringInfiniteList(tab, params);
+    useSuspenseGatheringInfiniteList(tab, filteredParams);
 
   const onIntersect: IntersectionObserverCallback = ([{ isIntersecting }]) => {
     if (isIntersecting && hasNextPage) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,10 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
 export function middleware(req: NextRequest) {
+  // 현재의 request url을 custom header에 저장
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.set("x-pathname", req.nextUrl.pathname);
+
   const token = req.cookies.get("authToken")?.value;
 
   // 토큰 없으면 401 응답
@@ -12,7 +16,12 @@ export function middleware(req: NextRequest) {
     );
   }
 
-  return NextResponse.next();
+  return NextResponse.next({
+    request: {
+      // 새로운 request headers 적용
+      headers: requestHeaders,
+    },
+  });
 }
 
 // 인증이 필요한 API 경로에만 동작하도록 설정

--- a/src/utils/gatheringFilterParams.ts
+++ b/src/utils/gatheringFilterParams.ts
@@ -1,6 +1,16 @@
 import { ONLINE, ONLINE_PATH } from "@/constants/gatheringFilterParams";
 import { IGatheringFilterParams } from "@/types/gathering";
 
+export const filterUndefined = (paramsObj: IGatheringFilterParams) => {
+  const filterParams = Object.entries(paramsObj)
+    .filter(([, value]) => value !== undefined)
+    .reduce((acc, value) => {
+      return { ...acc, [value[0]]: value[1] };
+    }, {});
+
+  return filterParams;
+};
+
 export const updateSortOption = (paramsObj: IGatheringFilterParams) => {
   const sortOption = paramsObj.sortBy;
 
@@ -39,7 +49,9 @@ export const updateGatheringParams = (
     delete paramsObj.location;
   }
 
-  const updatedSortParams = updateSortOption(paramsObj);
+  const filteredUndefined = filterUndefined(paramsObj);
+
+  const updatedSortParams = updateSortOption(filteredUndefined);
 
   return updatedSortParams;
 };

--- a/src/utils/gatheringFilterParams.ts
+++ b/src/utils/gatheringFilterParams.ts
@@ -1,20 +1,8 @@
 import { ONLINE, ONLINE_PATH } from "@/constants/gatheringFilterParams";
 import { IGatheringFilterParams } from "@/types/gathering";
 
-export const updateGatheringParams = (
-  pathname: string,
-  paramsObj: IGatheringFilterParams,
-) => {
-  const location = paramsObj.location;
+export const updateSortOption = (paramsObj: IGatheringFilterParams) => {
   const sortOption = paramsObj.sortBy;
-
-  if (pathname === ONLINE_PATH) {
-    paramsObj["location"] = ONLINE.location;
-  }
-
-  if (location === "전체") {
-    delete paramsObj.location;
-  }
 
   if (sortOption) {
     let order = "";
@@ -35,4 +23,23 @@ export const updateGatheringParams = (
   }
 
   return paramsObj;
+};
+
+export const updateGatheringParams = (
+  pathname: string,
+  paramsObj: IGatheringFilterParams,
+) => {
+  const location = paramsObj.location;
+
+  if (pathname === ONLINE_PATH) {
+    paramsObj["location"] = ONLINE.location;
+  }
+
+  if (location === "전체") {
+    delete paramsObj.location;
+  }
+
+  const updatedSortParams = updateSortOption(paramsObj);
+
+  return updatedSortParams;
 };


### PR DESCRIPTION
## 개요
- 모임 페이지에서 데이터 패칭 관련 개선 및 수정

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## 스크린샷 및 세부 내용 - 왜 해당 PR이 필요한지 자세하게 설명해주세요

- 모임 페이지에서 react-query prefetch를 사용해 서버의 페이지 렌더링 단계에서 데이터를 패칭하도록 수정했습니다.
- params를 변환하는 gatheringFilterParams를 수정했습니다.
  - 정렬 관련 params를 처리하는 부분을 updateSortOption 함수로 분리했습니다. 
  - params object value가 undefined일 경우 필터링하는 함수를 추가했습니다.
 - MainCardList에서 params를 변환하는 부분을 상위 컴포넌트(page.tsx)에서 진행되도록 변경
 
## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 코드리뷰 검토 사항을 적어주세요

- 전체적인 코드 구현 확인을 부탁드립니다.
- middleware.js를 수정했습니다.
