### PR TITLE
[#139]test: jest test coverage 측정을 위한 config 파일 변경[PLAK-187]

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -26,6 +26,24 @@ const config: Config = {
   ],
 
   clearMocks: true,
+
+  // coverage 측정시 필요한 provider (default: babel)
+  coverageProvider: "v8",
+
+  // coverage files 결과물을 출력하는 경로
+  coverageDirectory: "<rootDir>/coverage",
+
+  coverageReporters: ["clover", "json", "lcov", ["text", { skipFull: true }]],
+
+  // coverage 수집 범위 설정
+  collectCoverageFrom: [
+    "**/app/**/*.[jt]s?(x)",
+    "**/components/**/*.[jt]s?(x)",
+    "!**/*.stories.[jt]s?(x)",
+  ],
+
+  // coverage 수집 제외 범위 설정
+  coveragePathIgnorePatterns: [".next/"],
 };
 
 export default createJestConfig(config);

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test": "jest",
+    "coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "type-check": "tsc --noEmit"


### PR DESCRIPTION
## 개요
### 코드 커버리지

- **코드 커버리지**는 특정 Test Suite가 실행될 때 프로그램의 **소스 코드**가 실행되는 정도를 백분율로 측정한 것

### 코드 커버리지의 종류

- Statement coverage
- Branches coverage
- Function coverage
- **Line covergae**

### jest test coverage config 관련 options (jest.config.ts)

- coverageProvider
    - Indicates which provider should be used to instrument code for coverage. Allowed values are `babel` (default) or `v8`.
- collectCoverageFrom
    - default: 테스트 코드를 통해 사용되는 파일들에 대해서만 커버리지 목적으로 수집.
    - 값을 설정하면 경로에 해당되는 파일들에 대해 커버리지 수행한다. 추가하고 싶지 않은 경로가 있다면 ‘!’ 키워드를 활용.
    - collectCoverageFrom에 경로를 설정하더라도 test.ts 등의 테스트 목적의 파일과 같은 기본적인 수집 제외 대상 파일들은 여전히 커버리지 수집 대상이 되지 않음.
    
- coverageDirectory
    - coverage reporter 파일 directory 설정

- **collectCoverageFrom**
    - coverage 수집을 위한 범위 설정
    
- **coveragePathIgnorePatterns**
    - 커버리지 수집 제외 범위 설정
    - e.g) `coveragePathIgnorePatterns: [".next/"]`

- coverageThreshold
    - 커버리지 수집된 결과의 비율 한계점을 설정

- forceCoverageMatch
    - coverage에 기본적으로 담지 않는 파일들도 coverage 대상에 추가되도록 설정 (ex, 테스트 파일)
    - e.g) `forceCoverageMatch: ["**/*.test.{ts,tsx}"]`

### 참고한 자료
[jest config options]
- https://jestjs.io/docs/configuration#coverageprovider-string
- https://baekspace.tistory.com/266)](https://baekspace.tistory.com/266 - 커버리지의 종류 설명
- https://jforj.tistory.com/372
- https://www.daleseo.com/jest-coverage/

[jest code coverage provider]
- https://github.com/jestjs/jest/issues/11188
- https://blog.seokho.dev/ko/development/2023/09/23/how-to-collect-coverage-jest-v8.html - coverageProvider v8에 대해

## PR 유형

어떤 변경 사항이 있나요?
- [x] 기타(아래에 자세한 내용 기입해주세요)

## 스크린샷 및 세부 내용 - 왜 해당 PR이 필요한지 자세하게 설명해주세요
- test coverage를 측정합니다.

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 코드리뷰 검토 사항을 적어주세요

- jest.config.ts 파일 확인을 부탁드립니다.