### PR TITLE
[#67]refactor: PolymorphicHttpClient 작성 및 공통 로직 BaseHttpClient로 분리

### DIFF
--- a/src/hooks/auth/useUpdateUser.ts
+++ b/src/hooks/auth/useUpdateUser.ts
@@ -4,14 +4,13 @@ import authService from "@/services/auth/AuthService";
 import useModalStore from "@/stores/useModalStore";
 import useUserStore from "@/stores/useUserStore";
 import { APIError } from "@/types/error";
-import { IUpdateUser } from "@/types/user";
 
 export const useUpdateUser = () => {
   const { user, updateUserState } = useUserStore();
   const openAlert = useModalStore(state => state.openAlert);
 
   const { mutate: updateUser } = useMutation({
-    mutationFn: async (data: FormData): Promise<IUpdateUser> => {
+    mutationFn: async (data: FormData) => {
       return await authService.updateUser(data);
     },
     onSuccess: data => {

--- a/src/hooks/gathering/useCreateGathering.ts
+++ b/src/hooks/gathering/useCreateGathering.ts
@@ -15,7 +15,7 @@ export const useCreateGathering = () => {
       return gatheringService.createGathering(data);
     },
     onSuccess: async data => {
-      const gatheringId = data.id;
+      const gatheringId = String(data.id);
 
       await gatheringService.joinGathering(gatheringId);
 

--- a/src/services/BaseHttpClient.ts
+++ b/src/services/BaseHttpClient.ts
@@ -1,0 +1,68 @@
+export interface HTTPInstance {
+  get<R>(url: string, config?: RequestInit): Promise<R>;
+  post<T, R = T>(url: string, data?: T, config?: RequestInit): Promise<R>;
+  put<T, R = T>(url: string, data?: T, config?: RequestInit): Promise<R>;
+  delete<R>(url: string, config?: RequestInit): Promise<R>;
+}
+
+abstract class BaseHttpClient implements HTTPInstance {
+  protected abstract baseURL: string;
+  protected abstract attachCookies(headers: Headers): Promise<void>;
+
+  protected async request<R = unknown>(
+    method: string,
+    url: string,
+    data?: unknown,
+    config?: RequestInit,
+  ): Promise<R> {
+    const isFormData = data instanceof FormData;
+    const headers = new Headers(config?.headers);
+
+    if (!isFormData) {
+      headers.set("Content-Type", "application/json");
+    }
+
+    await this.attachCookies(headers);
+
+    const response = await fetch(this.baseURL + url, {
+      method,
+      headers,
+      body: isFormData ? data : data ? JSON.stringify(data) : undefined,
+      ...config,
+    });
+
+    const responseData: R = await response.json();
+
+    if (!response.ok) {
+      throw new Error("Network response was not ok");
+    }
+
+    return responseData;
+  }
+
+  public get<T>(url: string, config?: RequestInit): Promise<T> {
+    return this.request<T>("GET", url, undefined, config);
+  }
+
+  public post<T, R = T>(
+    url: string,
+    data?: T,
+    config?: RequestInit,
+  ): Promise<R> {
+    return this.request<R>("POST", url, data, config);
+  }
+
+  public put<T, R = T>(
+    url: string,
+    data?: T,
+    config?: RequestInit,
+  ): Promise<R> {
+    return this.request<R>("PUT", url, data, config);
+  }
+
+  public delete<R>(url: string, config?: RequestInit): Promise<R> {
+    return this.request<R>("DELETE", url, undefined, config);
+  }
+}
+
+export default BaseHttpClient;

--- a/src/services/HttpClient.ts
+++ b/src/services/HttpClient.ts
@@ -1,77 +1,18 @@
-interface HTTPInstance {
-  get<R>(url: string, config?: RequestInit): Promise<R>;
-  post<T, R>(url: string, data?: T, config?: RequestInit): Promise<R>;
-  put<T, R>(url: string, data?: T, config?: RequestInit): Promise<R>;
-  delete<R>(url: string, config?: RequestInit): Promise<R>;
-}
+import BaseHttpClient from "@/services/BaseHttpClient";
 
-class HttpClient implements HTTPInstance {
+class HttpClient extends BaseHttpClient {
   private static instance: HttpClient;
-  private baseURL: string;
+  protected baseURL = `${process.env.NEXT_PUBLIC_API_URL}`;
 
-  constructor() {
-    this.baseURL = `${process.env.NEXT_PUBLIC_API_URL}`;
+  protected async attachCookies() {
+    return;
   }
 
-  public static getInstance() {
+  public static getInstance(): HttpClient {
     if (!HttpClient.instance) {
       HttpClient.instance = new HttpClient();
     }
     return HttpClient.instance;
-  }
-
-  private async request<R = unknown>(
-    method: string,
-    url: string,
-    data?: unknown,
-    config?: RequestInit,
-  ): Promise<R> {
-    try {
-      const isFormData = data instanceof FormData;
-      const headers = new Headers(config?.headers);
-
-      if (!isFormData) {
-        headers.set("Content-Type", "application/json");
-      }
-
-      const response = await fetch(this.baseURL + url, {
-        method,
-        headers,
-        body: isFormData ? data : data ? JSON.stringify(data) : undefined,
-        ...config,
-      });
-
-      const responseData: R = await response.json();
-
-      if (!response.ok) {
-        throw new Error("Network response was not ok");
-      }
-
-      return responseData;
-    } catch (error) {
-      console.error("[Error]", method, url, error);
-      throw error;
-    }
-  }
-
-  public get<T>(url: string, config?: RequestInit): Promise<T> {
-    return this.request<T>("GET", url, undefined, config);
-  }
-
-  public post<T>(
-    url: string,
-    data?: unknown,
-    config?: RequestInit,
-  ): Promise<T> {
-    return this.request<T>("POST", url, data, config);
-  }
-
-  public put<T>(url: string, data?: unknown, config?: RequestInit): Promise<T> {
-    return this.request<T>("PUT", url, data, config);
-  }
-
-  public delete<R>(url: string, config?: RequestInit): Promise<R> {
-    return this.request<R>("DELETE", url, undefined, config);
   }
 }
 

--- a/src/services/PolymorphicHttpClient.ts
+++ b/src/services/PolymorphicHttpClient.ts
@@ -1,92 +1,23 @@
-interface HTTPInstance {
-  get<R>(url: string, config?: RequestInit): Promise<R>;
-  post<T, R>(url: string, data?: T, config?: RequestInit): Promise<R>;
-  put<T, R>(url: string, data?: T, config?: RequestInit): Promise<R>;
-  delete<R>(url: string, config?: RequestInit): Promise<R>;
-}
+import BaseHttpClient from "@/services/BaseHttpClient";
 
-/**
- * Server Side Rendering / Client Side Rendering
- * 모두 대응이 가능한 Service
- */
-
-class PolymorphicHttpClient implements HTTPInstance {
+class PolymorphicHttpClient extends BaseHttpClient {
   private static instance: PolymorphicHttpClient;
-  private baseURL: string;
+  protected baseURL = `${process.env.NEXT_PUBLIC_SITE_URL}/api`;
 
-  constructor(baseURL: string) {
-    this.baseURL = baseURL;
+  protected async attachCookies(headers: Headers) {
+    if (typeof window !== "undefined") return;
+
+    const { cookies } = await import("next/headers");
+    const _cookies = cookies().getAll();
+    const cookieStr = _cookies.map(c => `${c.name}=${c.value}`).join("; ");
+    headers.set("Cookie", cookieStr);
   }
 
-  public static getInstance(baseURL: string) {
+  public static getInstance(): PolymorphicHttpClient {
     if (!PolymorphicHttpClient.instance) {
-      PolymorphicHttpClient.instance = new PolymorphicHttpClient(baseURL);
+      PolymorphicHttpClient.instance = new PolymorphicHttpClient();
     }
     return PolymorphicHttpClient.instance;
-  }
-
-  private async request<R = unknown>(
-    method: string,
-    url: string,
-    data?: unknown,
-    config?: RequestInit,
-  ): Promise<R> {
-    try {
-      const isFormData = data instanceof FormData;
-      const headers = new Headers(config?.headers);
-
-      if (!isFormData) {
-        headers.set("Content-Type", "application/json");
-      }
-
-      if (typeof window === "undefined") {
-        await import("next/headers").then(({ cookies }) => {
-          const _cookies = cookies().getAll();
-          const cookieArr = _cookies
-            .map(cookie => `${cookie.name}=${cookie.value}`)
-            .join("; ");
-          headers.set("Cookie", cookieArr);
-        });
-      }
-
-      const response = await fetch(this.baseURL + url, {
-        method,
-        headers,
-        body: isFormData ? data : data ? JSON.stringify(data) : undefined,
-        ...config,
-      });
-
-      const responseData: R = await response.json();
-
-      if (!response.ok) {
-        throw new Error("Network response was not ok");
-      }
-
-      return responseData;
-    } catch (error) {
-      console.error("[Error]", method, url, error);
-      throw error;
-    }
-  }
-
-  public get<T>(url: string, config?: RequestInit): Promise<T> {
-    return this.request<T>("GET", url, undefined, config);
-  }
-
-  public post<T>(
-    url: string,
-    data?: unknown,
-    config?: RequestInit,
-  ): Promise<T> {
-    return this.request<T>("POST", url, data, config);
-  }
-
-  public put<T>(url: string, data?: unknown, config?: RequestInit): Promise<T> {
-    return this.request<T>("PUT", url, data, config);
-  }
-
-  public delete<R>(url: string, config?: RequestInit): Promise<R> {
-    return this.request<R>("DELETE", url, undefined, config);
   }
 }
 

--- a/src/services/PolymorphicHttpClient.ts
+++ b/src/services/PolymorphicHttpClient.ts
@@ -1,0 +1,93 @@
+interface HTTPInstance {
+  get<R>(url: string, config?: RequestInit): Promise<R>;
+  post<T, R>(url: string, data?: T, config?: RequestInit): Promise<R>;
+  put<T, R>(url: string, data?: T, config?: RequestInit): Promise<R>;
+  delete<R>(url: string, config?: RequestInit): Promise<R>;
+}
+
+/**
+ * Server Side Rendering / Client Side Rendering
+ * 모두 대응이 가능한 Service
+ */
+
+class PolymorphicHttpClient implements HTTPInstance {
+  private static instance: PolymorphicHttpClient;
+  private baseURL: string;
+
+  constructor(baseURL: string) {
+    this.baseURL = baseURL;
+  }
+
+  public static getInstance(baseURL: string) {
+    if (!PolymorphicHttpClient.instance) {
+      PolymorphicHttpClient.instance = new PolymorphicHttpClient(baseURL);
+    }
+    return PolymorphicHttpClient.instance;
+  }
+
+  private async request<R = unknown>(
+    method: string,
+    url: string,
+    data?: unknown,
+    config?: RequestInit,
+  ): Promise<R> {
+    try {
+      const isFormData = data instanceof FormData;
+      const headers = new Headers(config?.headers);
+
+      if (!isFormData) {
+        headers.set("Content-Type", "application/json");
+      }
+
+      if (typeof window === "undefined") {
+        await import("next/headers").then(({ cookies }) => {
+          const _cookies = cookies().getAll();
+          const cookieArr = _cookies
+            .map(cookie => `${cookie.name}=${cookie.value}`)
+            .join("; ");
+          headers.set("Cookie", cookieArr);
+        });
+      }
+
+      const response = await fetch(this.baseURL + url, {
+        method,
+        headers,
+        body: isFormData ? data : data ? JSON.stringify(data) : undefined,
+        ...config,
+      });
+
+      const responseData: R = await response.json();
+
+      if (!response.ok) {
+        throw new Error("Network response was not ok");
+      }
+
+      return responseData;
+    } catch (error) {
+      console.error("[Error]", method, url, error);
+      throw error;
+    }
+  }
+
+  public get<T>(url: string, config?: RequestInit): Promise<T> {
+    return this.request<T>("GET", url, undefined, config);
+  }
+
+  public post<T>(
+    url: string,
+    data?: unknown,
+    config?: RequestInit,
+  ): Promise<T> {
+    return this.request<T>("POST", url, data, config);
+  }
+
+  public put<T>(url: string, data?: unknown, config?: RequestInit): Promise<T> {
+    return this.request<T>("PUT", url, data, config);
+  }
+
+  public delete<R>(url: string, config?: RequestInit): Promise<R> {
+    return this.request<R>("DELETE", url, undefined, config);
+  }
+}
+
+export default PolymorphicHttpClient;

--- a/src/services/Service.ts
+++ b/src/services/Service.ts
@@ -1,7 +1,14 @@
 import HttpClient from "@/services/HttpClient";
+import PolymorphicHttpClient from "@/services/PolymorphicHttpClient";
 
 abstract class Service {
   protected http = HttpClient.getInstance();
+}
+
+export abstract class ApiRouteService {
+  protected http = PolymorphicHttpClient.getInstance(
+    `${process.env.NEXT_PUBLIC_SITE_URL}/api`,
+  );
 }
 
 export default Service;

--- a/src/services/Service.ts
+++ b/src/services/Service.ts
@@ -6,9 +6,7 @@ abstract class Service {
 }
 
 export abstract class ApiRouteService {
-  protected http = PolymorphicHttpClient.getInstance(
-    `${process.env.NEXT_PUBLIC_SITE_URL}/api`,
-  );
+  protected http = PolymorphicHttpClient.getInstance();
 }
 
 export default Service;

--- a/src/services/auth/AuthService.ts
+++ b/src/services/auth/AuthService.ts
@@ -1,41 +1,12 @@
-class AuthService {
+import { ApiRouteService } from "@/services/Service";
+
+class AuthService extends ApiRouteService {
   async getUser() {
-    const baseURL = process.env.NEXT_PUBLIC_SITE_URL;
-
-    const header = new Headers();
-    let res: Response;
-    if (typeof window === "undefined") {
-      await import("next/headers").then(({ cookies }) => {
-        const _cookies = cookies().getAll();
-        const cookieArr = _cookies
-          .map(cookie => `${cookie.name}=${cookie.value}`)
-          .join("; ");
-        header.set("Cookie", cookieArr);
-      });
-      res = await fetch(`${baseURL}/api/auths/user`, {
-        method: "GET",
-        credentials: "include",
-        headers: header,
-      });
-    } else {
-      res = await fetch("/api/auths/user", {
-        method: "GET",
-        credentials: "include",
-      });
-    }
-
-    if (!res.ok) throw await res.json();
-    return res.json();
+    return this.http.get("/auths/user");
   }
 
   async updateUser(formData: FormData) {
-    const res = await fetch("/api/auths/user", {
-      method: "PUT",
-      body: formData,
-    });
-
-    if (!res.ok) throw await res.json();
-    return res.json();
+    return this.http.put("/auths/user", formData);
   }
 }
 

--- a/src/services/auth/AuthService.ts
+++ b/src/services/auth/AuthService.ts
@@ -1,11 +1,12 @@
 import { ApiRouteService } from "@/services/Service";
+import { IUpdateUser, IUser } from "@/types/user";
 
 class AuthService extends ApiRouteService {
-  async getUser() {
+  async getUser(): Promise<IUser> {
     return this.http.get("/auths/user");
   }
 
-  async updateUser(formData: FormData) {
+  async updateUser(formData: FormData): Promise<IUpdateUser> {
     return this.http.put("/auths/user", formData);
   }
 }

--- a/src/services/gathering/GatheringService.ts
+++ b/src/services/gathering/GatheringService.ts
@@ -1,74 +1,30 @@
+import { ApiRouteService } from "@/services/Service";
 import { IMyGathering, IMyGatheringFilterParams } from "@/types/gathering";
 
-class GatheringService {
+class GatheringService extends ApiRouteService {
   async createGathering(formData: FormData) {
-    const res = await fetch("/api/gatherings", {
-      method: "POST",
-      body: formData,
-    });
-
-    if (!res.ok) throw await res.json();
-    return res.json();
+    return this.http.post("/gatherings", formData);
   }
 
   async joinGathering(id: string) {
-    const res = await fetch(`/api/gatherings/${id}/join`, {
-      method: "POST",
-    });
-
-    if (!res.ok) throw await res.json();
-    return res.json;
+    return this.http.post(`/gatherings/${id}/join`);
   }
 
   async deleteGathering(id: string) {
-    const res = await fetch(`/api/gatherings/${id}/cancel`, {
-      method: "PUT",
-    });
-
-    if (!res.ok) throw await res.json();
-    return res.json();
+    return this.http.put(`/gatherings/${id}/cancel`);
   }
 
   async leaveGathering(id: string) {
-    const res = await fetch(`/api/gatherings/${id}/leave`, {
-      method: "DELETE",
-    });
-
-    if (!res.ok) throw await res.json();
-    return res.json();
+    return this.http.delete(`/gatherings/${id}/leave`);
   }
 
   async getMyGatheringList(searchParams?: IMyGatheringFilterParams) {
     const paramStr = new URLSearchParams(
       (searchParams ?? {}) as Record<string, string>,
     ).toString();
-    const baseURL = process.env.NEXT_PUBLIC_SITE_URL;
-    const url = `/api/gatherings/joined${paramStr && `?${paramStr}`}`;
-
-    const header = new Headers();
-    let res: Response;
-    if (typeof window === "undefined") {
-      await import("next/headers").then(({ cookies }) => {
-        const _cookies = cookies().getAll();
-        const cookieArr = _cookies
-          .map(cookie => `${cookie.name}=${cookie.value}`)
-          .join("; ");
-        header.set("Cookie", cookieArr);
-      });
-      res = await fetch(`${baseURL}${url}`, {
-        method: "GET",
-        credentials: "include",
-        headers: header,
-      });
-    } else {
-      res = await fetch(url, {
-        method: "GET",
-        credentials: "include",
-      });
-    }
-
-    if (!res.ok) throw await res.json();
-    return res.json() as Promise<IMyGathering[]>;
+    return this.http.get<IMyGathering[]>(
+      `/gatherings/joined${paramStr && `?${paramStr}`}`,
+    );
   }
 }
 

--- a/src/services/gathering/GatheringService.ts
+++ b/src/services/gathering/GatheringService.ts
@@ -1,8 +1,14 @@
 import { ApiRouteService } from "@/services/Service";
-import { IMyGathering, IMyGatheringFilterParams } from "@/types/gathering";
+import {
+  IGathering,
+  IMyGathering,
+  IMyGatheringFilterParams,
+} from "@/types/gathering";
 
 class GatheringService extends ApiRouteService {
-  async createGathering(formData: FormData) {
+  async createGathering(
+    formData: FormData,
+  ): Promise<Omit<IGathering, "canceledAt">> {
     return this.http.post("/gatherings", formData);
   }
 

--- a/src/services/review/ReviewService.ts
+++ b/src/services/review/ReviewService.ts
@@ -1,17 +1,9 @@
 import { TReviewForm } from "@/schemas/reviewSchema";
+import { ApiRouteService } from "@/services/Service";
 
-class ReviewService {
+class ReviewService extends ApiRouteService {
   async createReview(data: TReviewForm) {
-    const res = await fetch("/api/reviews", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(data),
-    });
-
-    if (!res.ok) throw await res.json();
-    return res.json();
+    return this.http.post("/reviews", data);
   }
 }
 


### PR DESCRIPTION
## 개요
PolymorphicHttpClient 작성 및 공통 로직 BaseHttpClient로 분리

## PR 유형

어떤 변경 사항이 있나요?

- [x] 코드 리팩토링

## 스크린샷 및 세부 내용 - 왜 해당 PR이 필요한지 자세하게 설명해주세요

공통 HTTP 요청 로직을 추상화하기 위해 BaseHttpClient를 새롭게 도입하고,
기존 HttpClient, PolymorphicHttpClient 간 중복 코드를 제거하여 리팩토링을 진행했습니다.

- 중복된 request, get, post, put, delete 메서드를 BaseHttpClient로 통합
- HttpClient: 인증 필요 없는 CSR 요청 담당
- PolymorphicHttpClient: SSR 환경에서 쿠키 인증이 필요한 요청 담당

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 코드리뷰 검토 사항을 적어주세요

- 서비스 클래스에 새로운 HTTP 클라이언트 적용된 부분 이상 없는지 확인 부탁드립니다.