### PR TITLE
[#146]refactor: MyProfile 테스트 구조 개선 및 전체 리팩토링

### DIFF
--- a/src/app/mypage/_components/tests/MyProfile.test.tsx
+++ b/src/app/mypage/_components/tests/MyProfile.test.tsx
@@ -1,8 +1,10 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 
 import MyProfile from "@/app/mypage/_components/MyProfile";
-import useUserStore from "@/stores/useUserStore";
-import { mockUser } from "@/utils/test-utils/userMocking";
+import {
+  applyUserStoreSelectorMock,
+  mockUserStore,
+} from "@/utils/test-utils/userMocking";
 
 jest.mock("@/components/modals/edit-profile-modal/EditProfileModal", () => ({
   __esModule: true,
@@ -11,36 +13,19 @@ jest.mock("@/components/modals/edit-profile-modal/EditProfileModal", () => ({
 jest.mock("@/stores/useUserStore");
 
 describe("MyProfile", () => {
-  const mockUseUserStore = useUserStore as unknown as jest.Mock;
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
   it("유저 정보가 있을 때 프로필 정보가 렌더링된다.", () => {
-    mockUseUserStore.mockImplementation(selector =>
-      selector({
-        user: mockUser,
-        isLoggedIn: true,
-        isHydrated: true,
-      }),
-    );
+    const store = mockUserStore.loggedIn();
+    applyUserStoreSelectorMock(store);
 
     render(<MyProfile />);
     expect(screen.getByText("내 프로필")).toBeInTheDocument();
-    expect(screen.getByText(mockUser.name)).toBeInTheDocument();
-    expect(screen.getByText(mockUser.companyName)).toBeInTheDocument();
-    expect(screen.getByText(mockUser.email)).toBeInTheDocument();
+    expect(screen.getByText(store.user.name)).toBeInTheDocument();
+    expect(screen.getByText(store.user.companyName)).toBeInTheDocument();
+    expect(screen.getByText(store.user.email)).toBeInTheDocument();
   });
 
   it("유저 정보가 있을 때 수정 버튼이 활성화된다.", () => {
-    mockUseUserStore.mockImplementation(selector =>
-      selector({
-        user: mockUser,
-        isLoggedIn: true,
-        isHydrated: true,
-      }),
-    );
+    mockUserStore.loggedIn();
 
     render(<MyProfile />);
     const button = screen.getByRole("button");
@@ -48,26 +33,15 @@ describe("MyProfile", () => {
   });
 
   it("유저 정보가 없을 때 MyProfileSkeleton이 렌더링된다.", () => {
-    mockUseUserStore.mockImplementation(selector =>
-      selector({
-        user: null,
-        isLoggedIn: false,
-        isHydrated: true,
-      }),
-    );
+    const store = mockUserStore.loggedOut();
+    applyUserStoreSelectorMock(store);
 
     render(<MyProfile />);
     expect(screen.getByTestId("profile-skeleton")).toBeInTheDocument();
   });
 
   it("수정 버튼 클릭 시 EditProfileModal이 열린다.", () => {
-    mockUseUserStore.mockImplementation(selector =>
-      selector({
-        user: mockUser,
-        isLoggedIn: true,
-        isHydrated: true,
-      }),
-    );
+    mockUserStore.loggedIn();
 
     render(<MyProfile />);
     const button = screen.getByRole("button");

--- a/src/components/modals/create-review-modal/CreateReviewModal.tsx
+++ b/src/components/modals/create-review-modal/CreateReviewModal.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect } from "react";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 
 import LoadingSpinner from "@/components/common/LoadingSpinner";
 import Rating from "@/components/common/Rating";
@@ -43,7 +43,7 @@ const CreateReviewModal = ({
     formState: { errors },
     setValue,
     trigger,
-    watch,
+    control,
     reset,
   } = useForm<TReviewForm>({
     resolver: zodResolver(ReviewSchema),
@@ -53,6 +53,9 @@ const CreateReviewModal = ({
       comment: "",
     },
   });
+
+  const score = useWatch({ control, name: "score" });
+  const comment = useWatch({ control, name: "comment" });
 
   const { handleCreateReview, isPending, isError } = useCreateReview();
 
@@ -92,7 +95,7 @@ const CreateReviewModal = ({
           <div>
             <Label className={labelTitleStyle}>만족스러운 경험이었나요?</Label>
             <Rating
-              rating={watch("score")}
+              rating={score}
               isEditable={true}
               onRatingChange={handleRatingChange}
             />
@@ -126,10 +129,7 @@ const CreateReviewModal = ({
               variant="purple"
               className="h-[44px] w-full"
               disabled={
-                !!errors.score ||
-                !!errors.comment ||
-                watch("score") === 0 ||
-                !watch("comment")
+                !!errors.score || !!errors.comment || score === 0 || !comment
               }
               type="submit"
             >

--- a/src/components/modals/edit-profile-modal/EditProfileModal.tsx
+++ b/src/components/modals/edit-profile-modal/EditProfileModal.tsx
@@ -100,6 +100,7 @@ const EditProfileModal = ({ isOpen, onClose, user }: EditProfileModalProps) => {
               variant="purple"
               className="h-[44px] w-full"
               onClick={handleSubmit}
+              disabled={!companyName}
             >
               수정하기
             </Button>

--- a/src/components/modals/tests/EditProfileModal.test.tsx
+++ b/src/components/modals/tests/EditProfileModal.test.tsx
@@ -67,4 +67,16 @@ describe("EditProfileModal", () => {
     render(<EditProfileModal {...defaultProps} />);
     expect(screen.getByText("에러가 발생했습니다.")).toBeInTheDocument();
   });
+
+  it("회사명이 비어있을 경우 수정 버튼은 비활성화된다.", () => {
+    render(
+      <EditProfileModal
+        {...defaultProps}
+        user={{ ...defaultProps.user, companyName: "" }}
+      />,
+    );
+
+    const submitButton = screen.getByText("수정하기");
+    expect(submitButton).toBeDisabled();
+  });
 });

--- a/src/utils/test-utils/userMocking.ts
+++ b/src/utils/test-utils/userMocking.ts
@@ -1,4 +1,15 @@
 import useUserStore from "@/stores/useUserStore";
+import { IUser } from "@/types/user";
+
+type UserStore = {
+  user: IUser | null;
+  isLoggedIn: boolean;
+  isHydrated: boolean;
+  updateUserState?: (user: IUser) => void;
+  setUserState?: (user: IUser) => void;
+  clearUserState?: () => void;
+  setHydrated?: (state: boolean) => void;
+};
 
 /**
 // 로그인 상태 모킹 (기본값 사용)
@@ -67,4 +78,10 @@ export const mockUserStore = {
     (useUserStore as unknown as jest.Mock).mockReturnValue(mockStore);
     return mockStore;
   },
+};
+
+export const applyUserStoreSelectorMock = (store: UserStore) => {
+  (useUserStore as unknown as jest.Mock).mockImplementation(selector =>
+    typeof selector === "function" ? selector(store) : store,
+  );
 };


### PR DESCRIPTION
## 개요
MyProfile 테스트 구조 개선 및 전체 리팩토링
PR 리뷰 반영: 
- https://github.com/codeit-plake/plake/pull/166#discussion_r2034643776
- https://github.com/codeit-plake/plake/pull/166#discussion_r2034673947

## PR 유형

어떤 변경 사항이 있나요?

- [x] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링

## 스크린샷 및 세부 내용 - 왜 해당 PR이 필요한지 자세하게 설명해주세요

- `MyProfile` 테스트 내 `useUserStore` 모킹 방식을 `selector` 형태에 맞게 리팩토링  
  - 중복되는 store mocking 로직을 `userMocking.ts`에 유틸 함수로 추출하여 재사용성 확보  
  - 기존 `mockReturnValue` 방식에서 `mockImplementation(selector => selector(store))` 방식으로 개선  
- `EditProfileModal` 테스트에서 수정하기 버튼의 비활성화 상태 테스트 추가  
- `CreateReviewModal`의 watch 호출을 useWatch로 변경하여 불필요한 리렌더링 방지

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 코드리뷰 검토 사항을 적어주세요

- `applyUserStoreSelectorMock` 유틸 사용 방식이 괜찮은지 확인 부탁드립니다.  