### PR TITLE
[#164]fix: 로그인 불가 이슈 – 토큰 저장 순서 조정으로 해결

### DIFF
--- a/src/actions/user-signin-action.ts
+++ b/src/actions/user-signin-action.ts
@@ -28,6 +28,10 @@ const userSignInAction = async (_: any, formData: FormData) => {
       throw new Error(await response.text());
     }
 
+    // 토큰을 받아오면 쿠키에 저장
+    const res = await response.json();
+    await setCookieOfToken(res.token);
+
     // 로그인 성공 시 유저 정보 확인
     const chkResult = await userCheckAction();
 
@@ -35,10 +39,6 @@ const userSignInAction = async (_: any, formData: FormData) => {
     if (!chkResult.status) {
       throw new Error(chkResult.error);
     }
-
-    // 성공시 쿠키에 토큰 저장
-    const res = await response.json();
-    await setCookieOfToken(res.token);
 
     // 유저 정보 반환
     return {


### PR DESCRIPTION
## 개요
로그인 불가 이슈 – 토큰 저장 순서 조정으로 해결

## PR 유형

어떤 변경 사항이 있나요?

- [x] 버그 수정

## 스크린샷 및 세부 내용 - 왜 해당 PR이 필요한지 자세하게 설명해주세요

- 로그인 시 인증 토큰을 서버에서 응답 받은 뒤, 해당 토큰을 setCookieOfToken으로 쿠키에 저장하는 과정이 userCheckAction() 이후에 수행되고 있었습니다.
- 그런데 userCheckAction()은 클라이언트가 로그인된 상태(즉, 쿠키에 토큰이 존재하는 상태)를 전제로 동작하기 때문에, 토큰이 아직 저장되지 않은 상태에서는 항상 유효하지 않은 토큰으로 처리되고 있었습니다.
- 이에 따라 토큰 저장 시점을 userCheckAction() 호출 전에 수행하도록 순서를 조정하였습니다.

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 코드리뷰 검토 사항을 적어주세요

- 토큰 저장 위치 변경이 인증 흐름에 적절한지 확인 부탁드립니다.
