### PR TITLE
[#143]fix: 모임 카드에서 모바일일 때 좋아요 버튼 레이아웃 깨짐 해결

### DIFF
--- a/src/components/layout/MainCardContent.tsx
+++ b/src/components/layout/MainCardContent.tsx
@@ -40,7 +40,7 @@ const MainCardContent = ({
               {name}
             </p>
             <RxDividerVertical className="text-gray-900" />
-            <span className="ml-[3px] min-w-16 text-sm text-gray-700">
+            <span className="ml-[3px] min-w-14 text-sm text-gray-700">
               {location === ONLINE.location ? "온라인" : location}
             </span>
           </div>


### PR DESCRIPTION
## 개요
모임 카드에서 모바일일 때 좋아요 버튼 레이아웃이 깨지는 현상을 해결했습니다.

## PR 유형

어떤 변경 사항이 있나요?

- [x] CSS 등 사용자 UI 디자인 변경

## 스크린샷 및 세부 내용 - 왜 해당 PR이 필요한지 자세하게 설명해주세요
<img width="364" alt="image" src="https://github.com/user-attachments/assets/f4737e38-c8d5-414c-b50c-51ed431310ea" />

-  모임 카드에서 모바일일 때 좋아요 버튼 레이아웃 깨짐을 해결했습니다.

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 코드리뷰 검토 사항을 적어주세요

- 코드 확인을 부탁드립니다.
